### PR TITLE
Removed filename dependency

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 import datetime
+import shutil
 
 import pandas as pd
 import geopandas as gpd
@@ -10,12 +11,12 @@ from utils.hdx_api import query_api
 
 
 ACAPS_HDX_ADDRESS = 'acaps-covid19-government-measures-dataset'
-# TODO: Take this out
-ACAPS_DATASET_NAME = '20200330 ACAPS - COVID-19 Goverment Measures Dataset v3.xlsx'
 
 CRASH_MOVE_MAIN_DIR = os.path.join('2020-03-16-global-covid-19-response-group',
                                    'GIS',
                                    '1_Original_Data')
+
+ACAPS_DIR = 'ACAPS_Govt_Measures'
 
 NATURAL_EARTH_DIR = 'NaturalEarth'
 NATURAL_EARTH_ZIP_FILENAME = 'NE_admin_wld'
@@ -28,28 +29,32 @@ OUTPUT_FILENAME = 'wrl_government_measures_py_s0_acaps_pp_governmentmeasures.shp
 
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument('input_path', help='Path to crash move folder')
+    parser.add_argument('cmf_path', help='Path to crash move folder')
     parser.add_argument('-d', '--debug', action='store_true', help='Run without querying API')
     args = parser.parse_args()
     return args
 
 
-def main(input_path, debug=False):
+def main(cmf_path, debug=False):
     # Get the ACAPS data from HDX
     data_dir = get_temp_dir('covid19_acaps')
+    acaps_dir = os.path.join(cmf_path, CRASH_MOVE_MAIN_DIR, ACAPS_DIR)
     if not debug:
-        filepath = query_api(ACAPS_HDX_ADDRESS, data_dir)[ACAPS_DATASET_NAME]
+        filename = list(query_api(ACAPS_HDX_ADDRESS, data_dir).values())[0]
+        filepath = os.path.join(acaps_dir, filename)
+        # Copy to crash move folder
+        shutil.move(os.path.join(data_dir, filename), filepath)
     else:
-        filepath = os.path.join(data_dir, f'{ACAPS_DATASET_NAME}.XLSX')
-    # TODO: Copy file to crash move folder?
-    print(filepath)
-    df_acaps = pd.read_excel(filepath, sheet_name='Database')
+        # If debug, check datadir folder and take the last item
+        filename = sorted(os.listdir(acaps_dir))[-1]
+    # Read in the dataframe
+    df_acaps = pd.read_excel(os.path.join(acaps_dir, filename), sheet_name='Database')
     # TODO: Fetch NaturalEarth data?
     # Read in NaturalEarth data
     # TODO: Read in from original shapefile and add transformations here
-    input_filename = os.path.join(input_path, CRASH_MOVE_MAIN_DIR, NATURAL_EARTH_DIR, NATURAL_EARTH_ZIP_FILENAME)
+    input_filename = os.path.join(cmf_path, CRASH_MOVE_MAIN_DIR, NATURAL_EARTH_DIR, NATURAL_EARTH_ZIP_FILENAME)
     df_naturalearth = gpd.read_file(f'zip://{input_filename}.zip!{NATURAL_EARTH_FILENAME}.shp')
-    # Do the joidt.strftime('%Y-%m-%d')n
+    # Do the join
     df_output = df_naturalearth.merge(df_acaps, how='outer', left_on='ADM0_A3_IS', right_on='ISO')
     # Convert datetime column to string to write to shape file
     for colname in ['DATE_IMPLEMENTED', 'ENTRY_DATE']:
@@ -57,7 +62,7 @@ def main(input_path, debug=False):
     # Drop link because ESRI doesn't like it
     df_output = df_output.drop(columns=['LINK'])
     # Output to CMF
-    output_dir = os.path.join(input_path, CRASH_MOVE_MAIN_DIR, OUTPUT_DIR, datetime.date.today().strftime('%d%m'))
+    output_dir = os.path.join(cmf_path, CRASH_MOVE_MAIN_DIR, OUTPUT_DIR, datetime.date.today().strftime('%d%m'))
     try:
         os.mkdir(output_dir)
     except FileExistsError:
@@ -67,4 +72,4 @@ def main(input_path, debug=False):
 
 if __name__ == '__main__':
     args = parse_args()
-    main(args.input_path, debug=args.debug)
+    main(args.cmf_path, debug=args.debug)


### PR DESCRIPTION
Fixes #1, which was caused due to the changing ACAPS filename. Explicitly specifying this filename is no longer required. 